### PR TITLE
Bump OpenJDK on CentOS to 7u261

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ OpenJDK Docker Images built and maintained by XeniT
 
 * `alfresco-6.0-centos`, `alfresco-6.1-centos`, `jdk-11u7-centos-7`, `jdk-11-centos-7`, `jdk-11u7-centos`, `jdk-11-centos`
 * `alfresco-6.0-ubuntu`, `alfresco-6.1-ubuntu`, `jdk-11u7-ubuntu-18.04`, `jdk-11-ubuntu-18.04`, `jdk-11u7-bionic`, `jdk-11-bionic`
-* `jdk-7u221-centos-7`, `jdk-7-centos-7`, `jdk-7u221-centos`, `jdk-7-centos`
+* `jdk-7u261-centos-7`, `jdk-7-centos-7`, `jdk-7u261-centos`, `jdk-7-centos`
 * `alfresco-5.1-centos`, `alfresco-5.2-centos`, `jdk-8u252-centos-7`, `jdk-8-centos-7`, `jdk-8u252-centos`, `jdk-8-centos`
 * `alfresco-5.0-ubuntu`, `alfresco-5.1-ubuntu`, `alfresco-5.2-ubuntu`, `jdk-8u252-ubuntu-18.04`, `jdk-8-ubuntu-18.04`, `jdk-8u252-bionic`, `jdk-8-bionic`, `jdk-8u252-ubuntu`, `jdk-8-ubuntu`, `jdk-8u252`, `jdk-8`
 * `alfresco-4.2-ubuntu`, `jdk-7u211-ubuntu-14.04`, `jdk-7-ubuntu-14.04`, `jdk-7u211-trusty`, `jdk-7-trusty`

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ static List<String> calcTags (Project project) {
 
 static Map getLatestOpenjdkJavaRelease(major, vendor, osversion) {
     def result = [
-            [vendor: 'centos', osversion: '7', major: 7, update: 221],
+            [vendor: 'centos', osversion: '7', major: 7, update: 261],
             [vendor: 'ubuntu', osversion: '14.04', major: 7, update: 211],
     ].find { it.vendor.equals(vendor) && it.major == major && it.osversion.equals(osversion) }
     assert result != null : "No JDK version ${major} found for '${vendor} ${osversion}'"


### PR DESCRIPTION
This fixes the current failing build:
> No package java-1.7.0-openjdk-devel-1.7.0.221* available.