### PR TITLE
Update to jdk-11.0.9.1 and jdk-8u275

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,36 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## 2020-11
-
-### Changed
-
 * [2020-11-14] [PR #19](https://github.com/xenit-eu/docker-openjdk/pull/19) Updated to jdk-11.0.9.1 and jdk-8u275
 
 ## 2020-10
-
-### Changed
-
 * [2020-10-28] [PR #18](https://github.com/xenit-eu/docker-openjdk/pull/18) Updated to jdk-11.0.9 and jdk-8u272
 
 ## 2020-05
-
-### Changed
-
 * [2020-05-06] [PR #14](https://github.com/xenit-eu/docker-openjdk/pull/14) Updated jdk-7 on CentOS from 7u221 to 7u261
 
 ## 2020-04
-
-### Changed
-
 * [2020-04-17] [PR #13](https://github.com/xenit-eu/docker-openjdk/pull/13) Updated to [jdk-11.0.7](https://adoptopenjdk.net/release_notes.html?jvmVariant=hotspot#jdk11_0_7) and [jdk-8u252](https://adoptopenjdk.net/release_notes.html?jvmVariant=hotspot#jdk8u252)
 
 ## 2020-03
-
 * [2020-03-27] [PR #12](https://github.com/xenit-eu/docker-openjdk/pull/12) Updated to jdk-11.0.6 and jdk-8u242 
 * [2020-03-25] [PR #9](https://github.com/xenit-eu/docker-openjdk/pull/9) Dropped JDK-6 builds
 
 ## 2020-01
-
-### Changed
-
 * [2020-01-28] [PR #7](https://github.com/xenit-eu/docker-openjdk/pull/7) Base all JDK-8 Ubuntu images on bionic (18.04 LTS)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## 2020-11
+
+### Changed
+
+* [2020-11-14] [PR #19](https://github.com/xenit-eu/docker-openjdk/pull/19) Updated to jdk-11.0.9.1 and jdk-8u275
+
 ## 2020-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## 2020-11
-* [2020-11-14] [PR #19](https://github.com/xenit-eu/docker-openjdk/pull/19) Updated to jdk-11.0.9.1 and jdk-8u275
+* [2020-11-14] [PR #19](https://github.com/xenit-eu/docker-openjdk/pull/19) Update to jdk-11.0.9.1 and jdk-8u275
 
 ## 2020-10
-* [2020-10-28] [PR #18](https://github.com/xenit-eu/docker-openjdk/pull/18) Updated to jdk-11.0.9 and jdk-8u272
+* [2020-10-28] [PR #18](https://github.com/xenit-eu/docker-openjdk/pull/18) Update to jdk-11.0.9 and jdk-8u272
 
 ## 2020-05
-* [2020-05-06] [PR #14](https://github.com/xenit-eu/docker-openjdk/pull/14) Updated jdk-7 on CentOS from 7u221 to 7u261
+* [2020-05-06] [PR #14](https://github.com/xenit-eu/docker-openjdk/pull/14) Update jdk-7 on CentOS from 7u221 to 7u261
 
 ## 2020-04
-* [2020-04-17] [PR #13](https://github.com/xenit-eu/docker-openjdk/pull/13) Updated to [jdk-11.0.7](https://adoptopenjdk.net/release_notes.html?jvmVariant=hotspot#jdk11_0_7) and [jdk-8u252](https://adoptopenjdk.net/release_notes.html?jvmVariant=hotspot#jdk8u252)
+* [2020-04-17] [PR #13](https://github.com/xenit-eu/docker-openjdk/pull/13) Update to [jdk-11.0.7](https://adoptopenjdk.net/release_notes.html?jvmVariant=hotspot#jdk11_0_7) and [jdk-8u252](https://adoptopenjdk.net/release_notes.html?jvmVariant=hotspot#jdk8u252)
 
 ## 2020-03
-* [2020-03-27] [PR #12](https://github.com/xenit-eu/docker-openjdk/pull/12) Updated to jdk-11.0.6 and jdk-8u242 
-* [2020-03-25] [PR #9](https://github.com/xenit-eu/docker-openjdk/pull/9) Dropped JDK-6 builds
+* [2020-03-27] [PR #12](https://github.com/xenit-eu/docker-openjdk/pull/12) Update to jdk-11.0.6 and jdk-8u242 
+* [2020-03-25] [PR #9](https://github.com/xenit-eu/docker-openjdk/pull/9) Drop JDK-6 builds
 
 ## 2020-01
 * [2020-01-28] [PR #7](https://github.com/xenit-eu/docker-openjdk/pull/7) Base all JDK-8 Ubuntu images on bionic (18.04 LTS)

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ OpenJDK Docker Images built and maintained by XeniT
 
 ## Supported Tags
 
-* `alfresco-6.0-centos`, `alfresco-6.1-centos`, `alfresco-6.2-centos`,  `jdk-11u9-centos-7`, `jdk-11-centos-7`, `jdk-11u9-centos`, `jdk-11-centos`
-* `alfresco-6.0-ubuntu`, `alfresco-6.1-ubuntu`, `alfresco-6.2-ubuntu`, `jdk-11u9-ubuntu-18.04`, `jdk-11-ubuntu-18.04`, `jdk-11u9-bionic`, `jdk-11-bionic`
+* `alfresco-6.0-centos`, `alfresco-6.1-centos`, `alfresco-6.2-centos`,  `jdk-11u9.1-centos-7`, `jdk-11-centos-7`, `jdk-11u9.1-centos`, `jdk-11-centos`
+* `alfresco-6.0-ubuntu`, `alfresco-6.1-ubuntu`, `alfresco-6.2-ubuntu`, `jdk-11u9.1-ubuntu-18.04`, `jdk-11-ubuntu-18.04`, `jdk-11u9.1-bionic`, `jdk-11-bionic`
 * `jdk-7u261-centos-7`, `jdk-7-centos-7`, `jdk-7u261-centos`, `jdk-7-centos`
-* `alfresco-5.1-centos`, `alfresco-5.2-centos`, `jdk-8u272-centos-7`, `jdk-8-centos-7`, `jdk-8u272-centos`, `jdk-8-centos`
-* `alfresco-5.0-ubuntu`, `alfresco-5.1-ubuntu`, `alfresco-5.2-ubuntu`, `jdk-8u272-ubuntu-18.04`, `jdk-8-ubuntu-18.04`, `jdk-8u272-bionic`, `jdk-8-bionic`, `jdk-8u272-ubuntu`, `jdk-8-ubuntu`, `jdk-8u272`, `jdk-8`
+* `alfresco-5.1-centos`, `alfresco-5.2-centos`, `jdk-8u275-centos-7`, `jdk-8-centos-7`, `jdk-8u275-centos`, `jdk-8-centos`
+* `alfresco-5.0-ubuntu`, `alfresco-5.1-ubuntu`, `alfresco-5.2-ubuntu`, `jdk-8u275-ubuntu-18.04`, `jdk-8-ubuntu-18.04`, `jdk-8u275-bionic`, `jdk-8-bionic`, `jdk-8u275-ubuntu`, `jdk-8-ubuntu`, `jdk-8u275`, `jdk-8`
 * `alfresco-4.2-ubuntu`, `jdk-7u211-ubuntu-14.04`, `jdk-7-ubuntu-14.04`, `jdk-7u211-trusty`, `jdk-7-trusty`
 
 
@@ -75,7 +75,7 @@ openjdk:<type>-<version>-<os>
 There are permutations possible of three parameters in this project.
 
 * **Type**: the Java distribution type, one of `jdk`, `jre` or `server-jre`. At the moment only `jdk` is implemented.
-* **Version**: the Java version, for example `8u272`
+* **Version**: the Java version, for example `8u275`
 * **OS**: the Operating system, for example `ubuntu-18.04`, with optionally some additional variants
 
 Please file an issue if you need a different combination of parameters.
@@ -95,8 +95,8 @@ based on the latest LTS release, of that distribution.
     - `jdk-11-ubuntu`
     - `jdk-11-centos`
 
-**NOTE**: the Java _update_ (=minor version) is **NOT** maintained. For example: the current Ubuntu JDK 8 image is tagged with `jdk-8-ubuntu-18.04` and has the additional tag `jdk-8u272-ubuntu-18.04` to indicate the Java 8 _update_ version. 
-Once the next update is published, the image tagged `jdk-8-ubuntu-18.04` will be updated, but `jdk-8u272-ubuntu-18.04` will no longer be supported and will not receive OS or Java security patches.
+**NOTE**: the Java _update_ (=minor version) is **NOT** maintained. For example: the current Ubuntu JDK 8 image is tagged with `jdk-8-ubuntu-18.04` and has the additional tag `jdk-8u275-ubuntu-18.04` to indicate the Java 8 _update_ version. 
+Once the next update is published, the image tagged `jdk-8-ubuntu-18.04` will be updated, but `jdk-8u275-ubuntu-18.04` will no longer be supported and will not receive OS or Java security patches.
 
 Images are used as base images for building Alfresco. Supported stack for Alfresco is documented at (replace capital X's with the desired version):
 
@@ -111,12 +111,12 @@ At the moment, following versions are built:
 
 | Alfresco      | OpenJDk            | Ubuntu                             | CentOS                       |
 | ------------- | ------------------ | ---------------------------------- | ---------------------------- |
-| Alfresco 6.2  | JDK 11u9           | 18.04 - `jdk-11u9-ubuntu-18.04`    | 7 - `jdk-11u9-centos-7`      |
-| Alfresco 6.1  | JDK 11u9           | 18.04 - `jdk-11u9-ubuntu-18.04`    | 7 - `jdk-11u9-centos-7`      |
-| Alfresco 6.0  | JDK 11u9           | 18.04 - `jdk-11u9-ubuntu-18.04`    | 7 - `jdk-11u9-centos-7`      |
-| Alfresco 5.2  | JDK 8u272          | 18.04 - `jdk-8u272-ubuntu-18.04`   | 7 - `jdk-8u272-centos-7`     |
-| Alfresco 5.1  | JDK 8u272          | 18.04 - `jdk-8u272-ubuntu-18.04`   | 7 - `jdk-8u272-centos-7`     |
-| Alfresco 5.0  | JDK 8u272          | 18.04 - `jdk-8u272-ubuntu-18.04`   |                              |
+| Alfresco 6.2  | JDK 11u9.1           | 18.04 - `jdk-11u9.1-ubuntu-18.04`    | 7 - `jdk-11u9.1-centos-7`      |
+| Alfresco 6.1  | JDK 11u9.1           | 18.04 - `jdk-11u9.1-ubuntu-18.04`    | 7 - `jdk-11u9.1-centos-7`      |
+| Alfresco 6.0  | JDK 11u9.1           | 18.04 - `jdk-11u9.1-ubuntu-18.04`    | 7 - `jdk-11u9.1-centos-7`      |
+| Alfresco 5.2  | JDK 8u275          | 18.04 - `jdk-8u275-ubuntu-18.04`   | 7 - `jdk-8u275-centos-7`     |
+| Alfresco 5.1  | JDK 8u275          | 18.04 - `jdk-8u275-ubuntu-18.04`   | 7 - `jdk-8u275-centos-7`     |
+| Alfresco 5.0  | JDK 8u275          | 18.04 - `jdk-8u275-ubuntu-18.04`   |                              |
 | Alfresco 4.2  | JDK 7u211 (Oracle) | 14.04 - `jdk-7u211-ubuntu-14.04`   |                              |
 
 ### Operating Systems

--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,8 @@ static List<String> calcTags(Project project) {
 
 ext {
     ADOPTOPENJDK = [
-            8 : [major: 8, update: 272, extra: 'b10', esum: '6f124b69d07d8d3edf39b9aa5c58473f63a380b686ddb73a5495e01d25c2939a'],
-            11: [major: 11, update: 9, extra: '11', esum: 'a3c52b73a76bed0f113604165eb4f2020b767e188704d8cc0bfc8bc4eb596712'],
+            8 : [major: 8, update: 275, extra: 'b01', esum: '06fb04075ed503013beb12ab87963b2ca36abe9e397a0c298a57c1d822467c29'],
+            11: [major: 11, update: 9.1, extra: '1', esum: 'e388fd7f3f2503856d0b04fde6e151cbaa91a1df3bcebf1deddfc3729d677ca3'],
     ]
 
     ORACLEOPENJDK = [
@@ -122,7 +122,7 @@ subprojects { Project project ->
                 buildArgs.put('JAVA_VERSION', "${project.java.version.major}u${project.java.version.update}-${project.java.version.extra}");
                 buildArgs.put('JAVA_VERSION_COMPACT', "${project.java.version.major}u${project.java.version.update}${project.java.version.extra}");
             } else {
-                buildArgs.put('JAVA_VERSION', "-${project.java.version.major}.0.${project.java.version.update}+${project.java.version.extra}.1");
+                buildArgs.put('JAVA_VERSION', "-${project.java.version.major}.0.${project.java.version.update}+${project.java.version.extra}");
                 buildArgs.put('JAVA_VERSION_COMPACT', "${project.java.version.major}.0.${project.java.version.update}_${project.java.version.extra}");
             }
         }


### PR DESCRIPTION
Hello @tgeens,

I updated to the most recent versions of openjdk-8 (jdk-8u275) and openjdk-11 (jdk-11.0.9.1) available in package repositories on 2020-11-12.

A new release for CentOS 7 (7.9-2009) has been released on 2020-11-12, so the CentOS base image is going to be updated from 7.8-2003 to 7.9-2009 during rebuild.

Kind regards,
Koen